### PR TITLE
update model references from phi-3-mini to phi-3.5-mini

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ To enable AI copilot responses:
 
 ```powershell
 # Install Foundry Local from https://aka.ms/foundry-local
-foundry model run phi-3-mini
+foundry model run phi-3.5-mini
 ```
 
 Foundry Local runs on `http://localhost:5272`. Start the backend and frontend as above.

--- a/backend/src/services/copilot-service.js
+++ b/backend/src/services/copilot-service.js
@@ -628,7 +628,7 @@ async function handleCopilotChat(message, conversationHistory, twinState, simula
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          model: 'phi-3-mini',
+          model: 'phi-3.5-mini',
           messages,
           temperature: 0.7,
           max_tokens: 1024

--- a/blogpost.md
+++ b/blogpost.md
@@ -83,7 +83,7 @@ This app uses Foundry Local as a local inference endpoint for copilot responses.
 **Configuration:**
 
 - Endpoint: http://localhost:5272 (FOUNDRY_LOCAL_URL)
-- Model: phi-3-mini (selected for low latency and cost)
+- Model: phi-3.5-mini (selected for low latency and cost)
 - Request settings: temperature 0.7, max_tokens 1024
 
 **Why this model selection:**

--- a/docs/demo-script.md
+++ b/docs/demo-script.md
@@ -114,4 +114,4 @@ A: Uses simplified RC thermal models and ASHRAE guidelines for CO₂. Suitable f
 A: The architecture supports it - replace the simulator with a BACnet/Modbus connector to poll real sensors.
 
 **Q: What LLM does it use?**
-A: Foundry Local with Phi-3-mini by default, but supports any OpenAI-compatible endpoint.
+A: Foundry Local with Phi-3.5-mini by default, but supports any OpenAI-compatible endpoint.


### PR DESCRIPTION
in README, copilot-service, blogpost, and demo-script

fix #2 